### PR TITLE
Add a check to stop a silent fail when the user chooses an invalid directory

### DIFF
--- a/Chilano.Iso2God.Ftp/FtpUploader.cs
+++ b/Chilano.Iso2God.Ftp/FtpUploader.cs
@@ -71,6 +71,12 @@ public class FtpUploader : BackgroundWorker
 
             // in case user custom path has subfolders, mkdir and chdir recursively
             string[] CustomDirectories = ftpPath.Split('/');
+            // You can't make new folders in the root folder. If it doesn't already exist, it can't exist
+            if (!dirExists(CustomDirectories[0]))
+            {
+                Errors.Add(new NotSupportedException("The Xbox 360 does not allow you to create new folders in the root directory."));
+                return;
+            }
             foreach (string subDirectory in CustomDirectories)
             {
                 if (!dirExists(subDirectory))


### PR DESCRIPTION
This PR will cancel FTP uploads and tell the user that they've attempted to upload a game to a root directory that doesn't exist.

If you tell Iso2God to upload to a root directory that doesn't exist, like `Hdd69/Games`, instead of showing the user an error, it will just pretend that the upload completed successfully. It'll just say "Uploaded."

RGH (and I'm assuming all other types of modded) 360s do not allow you to create new folders in the root directory. Best case, FTP will throw an error (which this program does, but only when running in debug mode in Visual Studio), worst case it appears to cause a crash on the console itself. 

I encountered this problem naturally after I made a typo in the path, but I figured it would be best to make sure it's clear. 

I did try to incorporate another check in the FTP test window, but I couldn't get it working properly. Hopefully this is helpful :)